### PR TITLE
Add support for Claude in function_schema

### DIFF
--- a/function_schema/cli.py
+++ b/function_schema/cli.py
@@ -6,7 +6,9 @@ from .core import get_function_schema
 
 
 def print_usage():
-    print("Usage: function_schema <file_path> <function_name>")
+    print("Usage: function_schema <file_path> <function_name> [format='openai']")
+    print("Example: function_schema ./tests/test_schema.py test_simple_function")
+    print("Example: function_schema ./tests/test_schema.py test_simple_function claude")
 
 
 def main():
@@ -18,14 +20,25 @@ def main():
         spec.loader.exec_module(module)
         members = inspect.getmembers(module)
 
+        try:
+            format = sys.argv[3]
+        except IndexError:
+            format = "openai"
+        if format not in ["openai", "claude"]:
+            print(
+                "Invalid format. Use 'openai' or 'claude'. using 'openai'",
+                file=sys.stderr,
+            )
+
         for name, func in members:
-            if name == sys.argv[2]:
-                print(json.dumps(get_function_schema(func), indent=2))
+            if name >= sys.argv[2]:
+                print(json.dumps(get_function_schema(func, format), indent=2))
                 sys.exit(0)
         print(f"Function {sys.argv[2]} not found in {file_path}")
     except IndexError:
         print_usage()
         sys.exit(1)
+
 
 if __name__ == "__main__":
     main()

--- a/function_schema/core.py
+++ b/function_schema/core.py
@@ -12,7 +12,7 @@ def get_function_schema(
     func: typing.Annotated[typing.Callable, "The function to get the schema for"],
     format: typing.Annotated[
         typing.Optional[str], SchemaFormat, "The format of the schema to return"
-    ] = SchemaFormat.openai,
+    ] = "openai",
 ) -> typing.Annotated[dict[str, typing.Any], "The JSON schema for the given function"]:
     """
     Returns a JSON schema for the given function.

--- a/test/test_schema_type.py
+++ b/test/test_schema_type.py
@@ -1,0 +1,35 @@
+from typing import Annotated
+import enum
+from function_schema.core import get_function_schema
+
+
+def test_function_schema_type():
+    """Test a function schema for claude"""
+
+    def func1(
+        animal: Annotated[
+            str,
+            "The animal you want to pet",
+            enum.Enum("Animal", "Cat Dog"),
+        ],
+    ):
+        """My function"""
+        ...
+
+    schema = get_function_schema(func1)
+    assert (
+        schema["parameters"]["properties"]["animal"]["type"] == "string"
+    ), "parameter animal should be a string"
+    assert schema["parameters"]["properties"]["animal"]["enum"] == [
+        "Cat",
+        "Dog",
+    ], "parameter animal should have an enum"
+
+    schema2 = get_function_schema(func1, format="claude")
+    assert (
+        schema2["input_schema"]["properties"]["animal"]["type"] == "string"
+    ), "parameter animal should be a string"
+    assert schema2["input_schema"]["properties"]["animal"]["enum"] == [
+        "Cat",
+        "Dog",
+    ], "parameter animal should have an enum"


### PR DESCRIPTION
This pull request adds support for generating function schemas in the Claude format in the `function_schema` utility. It introduces a new optional argument `format` in the `get_function_schema` function, allowing users to specify the desired output format. The `format` argument accepts values of either "openai" or "claude". Additionally, a new test case `test_function_schema_type` has been added to ensure the correct generation of function schemas in the Claude format.