### PR TITLE
Support Literal type and code refactorings

### DIFF
--- a/function_schema/core.py
+++ b/function_schema/core.py
@@ -80,7 +80,7 @@ def get_function_schema(
             # find enum in param_args tuple
             enum_ = next(
                 (
-                    arg.name
+                    [e.name for e in arg]
                     for arg in param_args
                     if isinstance(arg, type) and issubclass(arg, enum.Enum)
                 ),

--- a/function_schema/core.py
+++ b/function_schema/core.py
@@ -1,7 +1,17 @@
 import enum
 import typing
-import types
 import inspect
+import platform
+import packaging.version
+
+current_version = packaging.version.parse(platform.python_version())
+py_310 = packaging.version.parse("3.10")
+
+if current_version >= py_310:
+    import types
+    from types import UnionType
+else:
+    UnionType = typing.Union  # type: ignore
 
 
 def get_function_schema(
@@ -139,7 +149,7 @@ def guess_type(
     origin = typing.get_origin(T)
 
     # hacking around typing modules, `typing.Union` and `types.UnitonType`
-    if origin is typing.Union or origin is types.UnionType:
+    if origin is typing.Union or origin is UnionType:
         union_types = [t for t in typing.get_args(T) if t is not type(None)]
         _types = []
         for union_type in union_types:

--- a/function_schema/core.py
+++ b/function_schema/core.py
@@ -1,5 +1,6 @@
 import enum
 import typing
+import types
 import inspect
 
 
@@ -138,7 +139,7 @@ def guess_type(
     origin = typing.get_origin(T)
 
     # hacking around typing modules, `typing.Union` and `types.UnitonType`
-    if origin is typing.Union:
+    if origin is typing.Union or origin is types.UnionType:
         union_types = [t for t in typing.get_args(T) if t is not type(None)]
         _types = []
         for union_type in union_types:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "function-schema"
-version = "0.3.0"
+version = "0.3.3"
 requires-python = ">= 3.9"
 description = "A small utility to generate JSON schemas for python functions."
 readme = "README.md"

--- a/test/test_guess_type.py
+++ b/test/test_guess_type.py
@@ -14,6 +14,22 @@ def test_primitive():
     assert guess_type(bool) == "boolean"
 
 
+def test_typings():
+    """Test typing module types"""
+    assert guess_type(typing.Any) == {}
+    assert guess_type(typing.List) == "array"
+    assert guess_type(typing.Dict) == "object"
+    assert guess_type(typing.Tuple) == "array"
+
+    assert guess_type(typing.List[int]) == "array"
+    assert guess_type(typing.List[str]) == "array"
+    assert guess_type(typing.List[float]) == "array"
+    assert guess_type(typing.List[bool]) == "array"
+
+    assert guess_type(typing.Dict[str, int]) == "object"
+    assert guess_type(typing.Dict[str, str]) == "object"
+
+
 def test_optional():
     """Test optional types"""
     assert guess_type(typing.Optional[int]) == "integer"
@@ -51,12 +67,15 @@ def test_union():
     ]
 
 
+current_version = packaging.version.parse(platform.python_version())
+py_310 = packaging.version.parse("3.10")
+
+
+@pytest.mark.skipif(
+    current_version < py_310, reason="Union type is only available in Python 3.10+"
+)
 def test_union_type():
     """Test union types in Python 3.10+"""
-    current_version = packaging.version.parse(platform.python_version())
-    py_310 = packaging.version.parse("3.10")
-    if current_version < py_310:
-        pytest.skip("Union type is only available in Python 3.10+")
 
     assert guess_type(int | str) == ["integer", "string"]
     assert guess_type(int | float) == "number"
@@ -75,3 +94,9 @@ def test_union_type():
         "number",
         "boolean",
     ]
+
+
+def test_literal_type():
+    """Test literal type"""
+    assert guess_type(typing.Literal["a"]) == "string"
+    assert guess_type(typing.Literal[1]) == "string"

--- a/test/test_schema.py
+++ b/test/test_schema.py
@@ -1,5 +1,5 @@
 import enum
-from typing import Optional, Annotated
+from typing import Annotated, Literal
 from function_schema.core import get_function_schema
 
 
@@ -86,6 +86,7 @@ def test_annotated_function():
 
 def test_annotated_function_with_enum():
     """Test a function with annotations and enum"""
+
     def func1(
         animal: Annotated[
             str,
@@ -101,6 +102,39 @@ def test_annotated_function_with_enum():
     assert (
         schema["parameters"]["properties"]["animal"]["type"] == "string"
     ), "parameter animal should be a string"
+    assert schema["parameters"]["properties"]["animal"]["enum"] == [
+        "Cat",
+        "Dog",
+    ], "parameter animal should have an enum"
+
+
+def test_literal_type():
+    """Test literal type"""
+
+    def func1(animal: Annotated[Literal["Cat", "Dog"], "The animal you want to pet"]):
+        """My function"""
+        ...
+
+    schema = get_function_schema(func1)
+    print(schema)
     assert (
-        schema["parameters"]["properties"]["animal"]["enum"] == ["Cat", "Dog"]
-    ), "parameter animal should have an enum"
+        schema["parameters"]["properties"]["animal"]["type"] == "string"
+    ), "parameter animal should be a string"
+    assert schema["parameters"]["properties"]["animal"]["enum"] == [
+        "Cat",
+        "Dog",
+    ], "parameter animal should have an enum"
+
+    def func2(animal: Literal["Cat", "Dog"]):
+        """My function"""
+        ...
+
+    schema = get_function_schema(func2)
+    assert (
+        schema["parameters"]["properties"]["animal"]["type"] == "string"
+    ), "parameter animal should be a string"
+
+    assert schema["parameters"]["properties"]["animal"]["enum"] == [
+        "Cat",
+        "Dog",
+    ], "parameter animal should have an enum"


### PR DESCRIPTION
This pull request adds support for the Literal type in the `get_function_schema` function and includes code refactorings for improved readability and maintainability. And also supports basic typs like `typing.List`, `typing.Tuple`, `typing.Dict`.