### PR TITLE
Fix enum handling in get_function_schema

### DIFF
--- a/function_schema/core.py
+++ b/function_schema/core.py
@@ -171,9 +171,7 @@ def guess_type(
         return _types
 
     if origin is typing.Literal:
-        return guess_type(
-            typing.Union[tuple({type(arg) for arg in typing.get_args(T)})]
-        )
+        return guess_type(typing.Union[tuple(type(arg) for arg in typing.get_args(T))])
     elif origin is list or origin is tuple:
         return "array"
     elif origin is dict:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "function-schema"
-version = "0.3.3"
+version = "0.3.4"
 requires-python = ">= 3.9"
 description = "A small utility to generate JSON schemas for python functions."
 readme = "README.md"

--- a/test/test_guess_type.py
+++ b/test/test_guess_type.py
@@ -101,18 +101,14 @@ def test_literal_type():
     assert guess_type(typing.Literal["a"]) == "string"
     assert guess_type(typing.Literal[1]) == "integer"
 
-    assert set(guess_type(typing.Literal["a", 1, None])) == set(["string", "integer"])
+    assert set(guess_type(typing.Literal["a", 1, None])) == {"string", "integer"}
 
-    assert set(guess_type(typing.Literal["a", 1])) == set(["string", "integer"])
-    assert set(guess_type(typing.Literal["a", 1.0])) == set(["string", "integer"])
-    assert set(guess_type(typing.Literal["a", 1.1])) == set(["string", "number"])
-    assert set(guess_type(typing.Literal["a", 1, 1.0])) == set(
-        [
-            "string",
-            "number",
-        ]
-    )  # XXX should be ["string", "integer", "number"] ?
+    assert set(guess_type(typing.Literal["a", 1])) == {"string", "integer"}
+    assert set(guess_type(typing.Literal["a", 1.0])) == {"string", "integer"}
+    assert set(guess_type(typing.Literal["a", 1.1])) == {"string", "number"}
+    assert set(guess_type(typing.Literal["a", 1, 1.0])) == {
+        "string",
+        "number",
+    }  # XXX should be ["string", "integer", "number"] ?
 
-    assert set(guess_type(typing.Literal["a", 1, 1.0, None])) == set(
-        ["string", "number"]
-    )
+    assert set(guess_type(typing.Literal["a", 1, 1.0, None])) == {"string", "number"}

--- a/test/test_guess_type.py
+++ b/test/test_guess_type.py
@@ -98,17 +98,21 @@ def test_union_type():
 
 def test_literal_type():
     """Test literal type"""
-    assert guess_type(typing.Literal["a"]) == "string"
-    assert guess_type(typing.Literal[1]) == "integer"
+    assert guess_type(typing.Literal["a"]) == "string", "should be string"
+    assert guess_type(typing.Literal[1]) == "integer", "should be integer"
+    assert guess_type(typing.Literal[1.0]) == "number", "should be number"
 
-    assert set(guess_type(typing.Literal["a", 1, None])) == {"string", "integer"}
+    assert set(guess_type(typing.Literal["a", 1, None])) == {
+        "string",
+        "integer",
+    }, "should be string or integer, omit None"
 
     assert set(guess_type(typing.Literal["a", 1])) == {"string", "integer"}
-    assert set(guess_type(typing.Literal["a", 1.0])) == {"string", "integer"}
+    assert set(guess_type(typing.Literal["a", 1.0])) == {"string", "number"}
     assert set(guess_type(typing.Literal["a", 1.1])) == {"string", "number"}
     assert set(guess_type(typing.Literal["a", 1, 1.0])) == {
         "string",
         "number",
-    }  # XXX should be ["string", "integer", "number"] ?
+    }, "should omit integer if number is present"
 
     assert set(guess_type(typing.Literal["a", 1, 1.0, None])) == {"string", "number"}

--- a/test/test_guess_type.py
+++ b/test/test_guess_type.py
@@ -99,4 +99,16 @@ def test_union_type():
 def test_literal_type():
     """Test literal type"""
     assert guess_type(typing.Literal["a"]) == "string"
-    assert guess_type(typing.Literal[1]) == "string"
+    assert guess_type(typing.Literal[1]) == "integer"
+
+    assert guess_type(typing.Literal["a", 1, None]) == ["string", "integer"]
+
+    assert guess_type(typing.Literal["a", 1]) == ["string", "integer"]
+    assert guess_type(typing.Literal["a", 1.0]) == ["string", "integer"]
+    assert guess_type(typing.Literal["a", 1.1]) == ["string", "number"]
+    assert guess_type(typing.Literal["a", 1, 1.0]) == [
+        "string",
+        "number",
+    ]  # XXX should be ["string", "integer", "number"] ?
+
+    assert guess_type(typing.Literal["a", 1, 1.0, None]) == ["string", "number"]

--- a/test/test_guess_type.py
+++ b/test/test_guess_type.py
@@ -101,14 +101,18 @@ def test_literal_type():
     assert guess_type(typing.Literal["a"]) == "string"
     assert guess_type(typing.Literal[1]) == "integer"
 
-    assert guess_type(typing.Literal["a", 1, None]) == ["string", "integer"]
+    assert set(guess_type(typing.Literal["a", 1, None])) == set(["string", "integer"])
 
-    assert guess_type(typing.Literal["a", 1]) == ["string", "integer"]
-    assert guess_type(typing.Literal["a", 1.0]) == ["string", "integer"]
-    assert guess_type(typing.Literal["a", 1.1]) == ["string", "number"]
-    assert guess_type(typing.Literal["a", 1, 1.0]) == [
-        "string",
-        "number",
-    ]  # XXX should be ["string", "integer", "number"] ?
+    assert set(guess_type(typing.Literal["a", 1])) == set(["string", "integer"])
+    assert set(guess_type(typing.Literal["a", 1.0])) == set(["string", "integer"])
+    assert set(guess_type(typing.Literal["a", 1.1])) == set(["string", "number"])
+    assert set(guess_type(typing.Literal["a", 1, 1.0])) == set(
+        [
+            "string",
+            "number",
+        ]
+    )  # XXX should be ["string", "integer", "number"] ?
 
-    assert guess_type(typing.Literal["a", 1, 1.0, None]) == ["string", "number"]
+    assert set(guess_type(typing.Literal["a", 1, 1.0, None])) == set(
+        ["string", "number"]
+    )

--- a/test/test_schema.py
+++ b/test/test_schema.py
@@ -116,7 +116,6 @@ def test_literal_type():
         ...
 
     schema = get_function_schema(func1)
-    print(schema)
     assert (
         schema["parameters"]["properties"]["animal"]["type"] == "string"
     ), "parameter animal should be a string"
@@ -138,3 +137,37 @@ def test_literal_type():
         "Cat",
         "Dog",
     ], "parameter animal should have an enum"
+
+    assert "animal" in schema["parameters"]["required"], "animal is required"
+
+    def func3(animal: Literal["Cat", "Dog", 1]):
+        """My function"""
+        ...
+
+    schema = get_function_schema(func3)
+    assert schema["parameters"]["properties"]["animal"]["type"] == [
+        "string",
+        "integer",
+    ], "parameter animal should be a string"
+
+    def func4(animal: Literal["Cat", "Dog", 1, None]):
+        """My function"""
+        ...
+
+    schema = get_function_schema(func4)
+
+    assert schema["parameters"]["properties"]["animal"]["type"] == [
+        "string",
+        "integer",
+    ], "parameter animal should be a string"
+
+    assert schema["parameters"]["properties"]["animal"]["enum"] == [
+        "Cat",
+        "Dog",
+        1,
+    ], "parameter animal should have an enum"
+
+    assert (
+        schema["parameters"].get("required") is None
+        or "animal" not in schema["parameters"]["required"]
+    ), "animal should not be required"

--- a/test/test_schema.py
+++ b/test/test_schema.py
@@ -47,10 +47,10 @@ def test_function_with_args():
     assert (
         schema["parameters"]["properties"]["c"]["default"] == 1.0
     ), "c should have a default value of 1.0"
-    assert schema["parameters"]["required"] == [
-        "a",
-        "b",
-    ], "parameters with no default value should be required"
+    assert (
+        "a" in schema["parameters"]["required"]
+        and "b" in schema["parameters"]["required"]
+    ), "parameters with no default value should be required"
 
 
 def test_annotated_function():
@@ -78,10 +78,10 @@ def test_annotated_function():
         schema["parameters"]["properties"]["b"]["description"] == "A string parameter"
     ), "parameter b should have a description"
 
-    assert schema["parameters"]["required"] == [
-        "a",
-        "b",
-    ], "parameters with no default value should be required"
+    assert (
+        "a" in schema["parameters"]["required"]
+        and "b" in schema["parameters"]["required"]
+    ), "parameters with no default value should be required"
 
 
 def test_annotated_function_with_enum():


### PR DESCRIPTION
This pull request fixes the handling of enums in the `get_function_schema` function.

Previously, the function did not correctly handle the case when the enum contained `None` values.

This PR ensures that `None` values are excluded from the enum list. Additionally, the PR updates the logic to correctly handle the case when the enum is a `Literal` type.