### PR TITLE
Implement PEP-0727 Doc in Annotation metadata

### DIFF
--- a/function_schema/core.py
+++ b/function_schema/core.py
@@ -38,7 +38,7 @@ def is_doc_meta(obj):
     """
     return getattr(obj, '__class__') == Doc and hasattr(obj, 'documentation')
 
-def unwrap_doc(obj: Doc | str):
+def unwrap_doc(obj: typing.Union[Doc, str]):
     """
     Get the documentation string from the given object.
     Parameters:

--- a/function_schema/core.py
+++ b/function_schema/core.py
@@ -12,6 +12,50 @@ if current_version >= py_310:
 else:
     UnionType = typing.Union  # type: ignore
 
+try:
+    from typing import Doc
+except ImportError:
+    try:
+        from typing_extensions import Doc
+    except ImportError:
+        class Doc:
+            def __init__(self, documentation: str, /):
+                self.documentation = documentation
+
+__all__ = ("get_function_schema", "guess_type", "Doc")
+
+def is_documentation(obj):
+    """
+    Check if the given object is a documentation object.
+    Parameters:
+        obj (object): The object to be checked.
+    Returns:
+        bool: True if the object is a documentation object, False otherwise.
+
+    Example:
+    >>> is_documentation(Doc("This is a documentation object"))
+    True
+    """
+    return getattr(obj, '__class__') == Doc and hasattr(obj, 'documentation')
+
+def unref_doc(obj: Doc | str):
+    """
+    Get the documentation string from the given object.
+    Parameters:
+        obj (Doc | str): The object to get the documentation string from.
+    Returns:
+        str: The documentation string.
+
+    Example:
+    >>> unref_doc(Doc("This is a documentation object"))
+    'This is a documentation object
+    >>> unref_doc("This is a documentation string")
+    'This is a documentation string'
+    """
+    if is_documentation(obj):
+        return obj.documentation
+    return str(obj)
+
 
 def get_function_schema(
     func: typing.Annotated[typing.Callable, "The function to get the schema for"],
@@ -83,7 +127,7 @@ def get_function_schema(
 
             # find description in param_args tuple
             description = next(
-                (arg for arg in param_args if isinstance(arg, str)),
+                (unref_doc(arg) for arg in param_args if isinstance(arg, (Doc, str))),
                 f"The {name} parameter",
             )
 

--- a/function_schema/core.py
+++ b/function_schema/core.py
@@ -24,7 +24,7 @@ except ImportError:
 
 __all__ = ("get_function_schema", "guess_type", "Doc")
 
-def is_documentation(obj):
+def is_doc_meta(obj):
     """
     Check if the given object is a documentation object.
     Parameters:
@@ -33,12 +33,12 @@ def is_documentation(obj):
         bool: True if the object is a documentation object, False otherwise.
 
     Example:
-    >>> is_documentation(Doc("This is a documentation object"))
+    >>> is_doc_meta(Doc("This is a documentation object"))
     True
     """
     return getattr(obj, '__class__') == Doc and hasattr(obj, 'documentation')
 
-def unref_doc(obj: Doc | str):
+def unwrap_doc(obj: Doc | str):
     """
     Get the documentation string from the given object.
     Parameters:
@@ -47,12 +47,12 @@ def unref_doc(obj: Doc | str):
         str: The documentation string.
 
     Example:
-    >>> unref_doc(Doc("This is a documentation object"))
-    'This is a documentation object
-    >>> unref_doc("This is a documentation string")
+    >>> unwrap_doc(Doc("This is a documentation object"))
+    'This is a documentation object'
+    >>> unwrap_doc("This is a documentation string")
     'This is a documentation string'
     """
-    if is_documentation(obj):
+    if is_doc_meta(obj):
         return obj.documentation
     return str(obj)
 
@@ -127,7 +127,7 @@ def get_function_schema(
 
             # find description in param_args tuple
             description = next(
-                (unref_doc(arg) for arg in param_args if isinstance(arg, (Doc, str))),
+                (unwrap_doc(arg) for arg in param_args if isinstance(arg, (Doc, str))),
                 f"The {name} parameter",
             )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,9 +17,6 @@ classifiers = [
   "Programming Language :: Python :: 3.9",
 ]
 
-[project.optional-dependencies]
-test = ["pytest"]
-
 [project.urls]
 Homepage = "https://github.com/comfuture/function-schema"
 Repository = "https://github.com/comfuture/function-schema"
@@ -30,3 +27,9 @@ function_schema = "function_schema.cli:main"
 [build-system]
 requires = ["flit_core >=3.9,<4"]
 build-backend = "flit_core.buildapi"
+
+[tool.uv]
+dev-dependencies = [
+    "pytest>=8.3.2",
+    "typing-extensions>=4.12.2",
+]

--- a/test/test_pep_0727_doc.py
+++ b/test/test_pep_0727_doc.py
@@ -1,0 +1,33 @@
+from typing import Annotated
+from enum import Enum
+from function_schema.core import get_function_schema, Doc
+
+
+def test_docs_in_annotation():
+    """Test a function with annotations with Doc"""
+    def func1(a: Annotated[int, Doc("An integer parameter")]):
+        """My function"""
+        ...
+
+    schema = get_function_schema(func1)
+    assert schema["name"] == "func1", "Function name should be func1"
+    assert schema["description"] == "My function", "Function description should be there"
+    assert schema["parameters"]["properties"]["a"]["type"] == "number", "parameter a should be an integer"
+    assert schema["parameters"]["properties"]["a"]["description"] == "An integer parameter", "parameter a should have a description"
+    assert schema["parameters"]["required"] == [
+        "a"], "parameter a should be required"
+
+
+def test_doc_in_nth_args():
+    """Test a function with annotations with Doc in nth args"""
+    def func1(a: Annotated[str, Enum("Candidates", "a b c"), Doc("A string parameter")]):
+        """My function"""
+        ...
+
+    schema = get_function_schema(func1)
+    assert schema["name"] == "func1", "Function name should be func1"
+    assert schema["description"] == "My function", "Function description should be there"
+    assert schema["parameters"]["properties"]["a"]["type"] == "string", "parameter a should be an string"
+    assert schema["parameters"]["properties"]["a"]["description"] == "A string parameter", "parameter a should have a description"
+    assert schema["parameters"]["properties"]["a"]["enum"] == [
+        "a", "b", "c"], "parameter a should have enum values"

--- a/uv.lock
+++ b/uv.lock
@@ -24,11 +24,6 @@ name = "function-schema"
 version = "0.3.6"
 source = { editable = "." }
 
-[package.optional-dependencies]
-test = [
-    { name = "pytest" },
-]
-
 [package.dev-dependencies]
 dev = [
     { name = "pytest" },
@@ -36,7 +31,6 @@ dev = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "pytest", marker = "extra == 'test'" }]
 
 [package.metadata.requires-dev]
 dev = [

--- a/uv.lock
+++ b/uv.lock
@@ -21,7 +21,7 @@ wheels = [
 
 [[package]]
 name = "function-schema"
-version = "0.3.5"
+version = "0.3.6"
 source = { editable = "." }
 
 [package.optional-dependencies]
@@ -29,8 +29,20 @@ test = [
     { name = "pytest" },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
+    { name = "typing-extensions" },
+]
+
 [package.metadata]
 requires-dist = [{ name = "pytest", marker = "extra == 'test'" }]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "pytest", specifier = ">=8.3.2" },
+    { name = "typing-extensions", specifier = ">=4.12.2" },
+]
 
 [[package]]
 name = "iniconfig"
@@ -83,4 +95,13 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c0/3f/d7af728f075fb08564c5949a9c95e44352e23dee646869fa104a3b2060a3/tomli-2.0.1.tar.gz", hash = "sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f", size = 15164 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/97/75/10a9ebee3fd790d20926a90a2547f0bf78f371b2f13aa822c759680ca7b9/tomli-2.0.1-py3-none-any.whl", hash = "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc", size = 12757 },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.12.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/df/db/f35a00659bc03fec321ba8bce9420de607a1d37f8342eee1863174c69557/typing_extensions-4.12.2.tar.gz", hash = "sha256:1a7ead55c7e559dd4dee8856e3a88b41225abfe1ce8df57b7c13915fe121ffb8", size = 85321 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/26/9f/ad63fc0248c5379346306f8668cda6e2e2e9c95e01216d2b8ffd9ff037d0/typing_extensions-4.12.2-py3-none-any.whl", hash = "sha256:04e5ca0351e0f3f85c6853954072df659d0d13fac324d0072316b67d7794700d", size = 37438 },
 ]


### PR DESCRIPTION
- Now accepts metadata in the PEP-0727 Doc in Annotation format.
- Maintains compatibility with existing `str` type docs annotations.