### PR TITLE
Enhance `Doc` in `Annotation` and implement its tests

### DIFF
--- a/function_schema/__init__.py
+++ b/function_schema/__init__.py
@@ -3,7 +3,7 @@ A small utility to generate JSON schemas for python functions.
 """
 from .core import get_function_schema
 
-__version__ = "0.4.0"
+__version__ = "0.4.1"
 __all__ = (
     "get_function_schema",
     "__version__",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "function-schema"
-version = "0.4.0"
+version = "0.4.1"
 requires-python = ">= 3.9"
 description = "A small utility to generate JSON schemas for python functions."
 readme = "README.md"

--- a/test/test_pep_0727_doc.py
+++ b/test/test_pep_0727_doc.py
@@ -31,3 +31,29 @@ def test_doc_in_nth_args():
     assert schema["parameters"]["properties"]["a"]["description"] == "A string parameter", "parameter a should have a description"
     assert schema["parameters"]["properties"]["a"]["enum"] == [
         "a", "b", "c"], "parameter a should have enum values"
+
+
+def test_multiple_docs_in_annotation():
+    """Test a function with annotations with multiple Doc"""
+    def func1(a: Annotated[int, Doc("An integer parameter"), Doc("A number")]):
+        """My function"""
+        ...
+
+    schema = get_function_schema(func1)
+    assert schema["name"] == "func1", "Function name should be func1"
+    assert schema["description"] == "My function", "Function description should be there"
+    assert schema["parameters"]["properties"]["a"]["type"] == "number", "parameter a should be an integer"
+    assert schema["parameters"]["properties"]["a"]["description"] == "An integer parameter", "first description should be used"
+
+
+def test_mixed_docs_in_annotation():
+    """Test a function with annotations with mixed Doc and strings"""
+    def func1(a: Annotated[int, "An integer parameter", Doc("A number")]):
+        """My function"""
+        ...
+
+    schema = get_function_schema(func1)
+    assert schema["name"] == "func1", "Function name should be func1"
+    assert schema["description"] == "My function", "Function description should be there"
+    assert schema["parameters"]["properties"]["a"]["type"] == "number", "parameter a should be an integer"
+    assert schema["parameters"]["properties"]["a"]["description"] == "A number", "`Doc` should be used rather than string"

--- a/uv.lock
+++ b/uv.lock
@@ -21,7 +21,7 @@ wheels = [
 
 [[package]]
 name = "function-schema"
-version = "0.3.6"
+version = "0.4.0"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
This pull request enhances the `Doc` metadata in the `Annotation` module and adds tests for it. It also includes updates the usage of `Doc` meta in the README file. The changes ensure that the `Doc` metadata is properly used for describing parameters and providing additional information in type hints. The pull request also includes examples and documentation on how to use `Doc` with different types of annotations, such as `Literal` and `Enum`.