### PR TITLE
Add packaging to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,9 @@
 name = "function-schema"
 version = "0.4.2"
 requires-python = ">= 3.9"
+dependencies = [
+  "packaging"
+]
 description = "A small utility to generate JSON schemas for python functions."
 readme = "README.md"
 license = {text = "MIT License"}


### PR DESCRIPTION
Straightforward fix by just adding it to `pyproject.toml`.