### PR TITLE
Refactor `Doc` class to support Protocols

### DIFF
--- a/function_schema/types.py
+++ b/function_schema/types.py
@@ -1,4 +1,4 @@
-from typing import TypedDict, Literal
+from typing import TypedDict, Literal, Protocol, runtime_checkable
 
 try:
     from typing import NotRequired
@@ -15,7 +15,10 @@ except ImportError:
         from typing_extensions import Doc
     except ImportError:
 
-        class Doc:
+        @runtime_checkable
+        class Doc(Protocol):
+            documentation: str
+
             def __init__(self, documentation: str, /):
                 self.documentation = documentation
 

--- a/function_schema/utils.py
+++ b/function_schema/utils.py
@@ -1,4 +1,4 @@
-from typing import Annotated, Any, Union
+from typing import Annotated, Union
 from .types import Doc
 
 
@@ -9,21 +9,6 @@ def is_support_uniontype():
     except ImportError:
         return False
     return True
-
-
-def is_doc_meta(
-    obj: Annotated[Any, Doc("The object to be checked.")],
-) -> Annotated[
-    bool, Doc("True if the object is a documentation object, False otherwise.")
-]:
-    """
-    Check if the given object is a documentation object.
-
-    Example:
-    >>> is_doc_meta(Doc("This is a documentation object"))
-    True
-    """
-    return getattr(obj, "__class__") == Doc and hasattr(obj, "documentation")
 
 
 def unwrap_doc(
@@ -41,6 +26,6 @@ def unwrap_doc(
     >>> unwrap_doc("This is a documentation string")
     'This is a documentation string'
     """
-    if is_doc_meta(obj):
+    if isinstance(obj, Doc):
         return obj.documentation
     return str(obj)


### PR DESCRIPTION
Implement Protocol support for the `Doc` class to enhance type checking and improve the handling of documentation objects. Remove the deprecated `is_doc_meta` function to streamline the code.