### PR TITLE
Refactor Doc type handling to use DocMeta protocol

### DIFF
--- a/function_schema/core.py
+++ b/function_schema/core.py
@@ -12,7 +12,7 @@ from typing import (
     get_type_hints,
 )
 
-from .types import FunctionSchema, Doc
+from .types import FunctionSchema, Doc, DocMeta
 from .utils import unwrap_doc
 
 
@@ -102,7 +102,7 @@ def get_function_schema(
             # find description in param_args tuple
             try:
                 description = next(
-                    unwrap_doc(arg) for arg in param_args if isinstance(arg, Doc)
+                    unwrap_doc(arg) for arg in param_args if isinstance(arg, DocMeta)
                 )
             except StopIteration:
                 try:

--- a/function_schema/types.py
+++ b/function_schema/types.py
@@ -15,12 +15,18 @@ except ImportError:
         from typing_extensions import Doc
     except ImportError:
 
-        @runtime_checkable
-        class Doc(Protocol):
+        class Doc:
             documentation: str
 
             def __init__(self, documentation: str, /):
                 self.documentation = documentation
+
+
+@runtime_checkable
+class DocMeta(Protocol):
+    """Represents the protocol for the Doc class."""
+
+    documentation: str
 
 
 class ParamSchema(TypedDict):


### PR DESCRIPTION
Update the handling of document types to utilize the DocMeta protocol, enhancing type safety and clarity in the codebase.